### PR TITLE
Add RPM packaging to workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,15 +3,17 @@ name: Release
 on: workflow_dispatch
 
 env:
-  FPM_OPTS: >-
-    -s dir --prefix '/usr' -n kvrocks --verbose -a native 
-    --config-files /usr/share/kvrocks/kvrocks.conf 
-    --description 'A distributed key value NoSQL database that uses RocksDB as storage engine and is compatible with Redis protocol' 
+  DEB_FPM_OPTS: >-
+    --prefix '/usr'
+    --config-files /usr/share/kvrocks/kvrocks.conf
+  COMMON_FPM_OPTS: >-
+    -s dir -n kvrocks --verbose -a native
+    --description 'A distributed key value NoSQL database that uses RocksDB as storage engine and is compatible with Redis protocol'
     --url 'https://kvrocks.apache.org' --license 'Apache-2.0'
 
 jobs:
   release-packages:
-    name: Release DEB Package
+    name: Release DEB & RPM Package
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4.0.0
@@ -33,7 +35,7 @@ jobs:
           cd kvrocks
           ./x.py build -DPORTABLE=1 -DCMAKE_BUILD_TYPE=Release -j $(nproc)
       
-      - name: Make release directory
+      - name: Make DEB release directory
         run: |
           mkdir release
           mkdir release/bin release/share
@@ -44,11 +46,30 @@ jobs:
           cp -r kvrocks/LICENSE kvrocks/NOTICE kvrocks/licenses release/share/kvrocks
           cp kvrocks/utils/systemd/kvrocks.service release/share/kvrocks
 
-      - name: Package Deb
+      - name: Package DEB
         uses: bpicode/github-action-fpm@v0.9.3
         with:
           fpm_args: '.'
-          fpm_opts: '-t deb -v ${{ env.VERSION }} --iteration ${{ env.ITERATION }} -C release ${{ env.FPM_OPTS }}'
+          fpm_opts: '-t deb -v ${{ env.VERSION }} --iteration ${{ env.ITERATION }} -C release ${{ env.COMMON_FPM_OPTS }} ${{ env.DEB_FPM_OPTS }}'
+      
+      - name: Make RPM release directory
+        run: |
+          mkdir -p rpm-release/etc/kvrocks
+          mkdir -p rpm-release/usr/bin
+          mkdir -p rpm-release/usr/lib/systemd/system
+          mkdir -p rpm-release/usr/share/licenses/kvrocks
+
+          cp kvrocks/build/kvrocks rpm-release/usr/bin/
+          cp kvrocks/build/kvrocks2redis rpm-release/usr/bin/
+          cp kvrocks/kvrocks.conf rpm-release/etc/kvrocks/
+          cp -r kvrocks/LICENSE kvrocks/NOTICE kvrocks/licenses/* rpm-release/usr/share/licenses/kvrocks/
+          cp kvrocks/utils/systemd/kvrocks.service rpm-release/usr/lib/systemd/system/
+
+      - name: Package RPM
+        uses: bpicode/github-action-fpm@v0.9.3
+        with:
+          fpm_args: '.'
+          fpm_opts: '-t rpm -v ${{ env.VERSION }} --iteration ${{ env.ITERATION }} -C rpm-release ${{ env.COMMON_FPM_OPTS }}'
 
       - name: Release
         uses: softprops/action-gh-release@v2.0.6
@@ -57,5 +78,6 @@ jobs:
             ${{ env.VERSION }}-${{ env.ITERATION }}
           files: |
             ./*.deb
+            ./*.rpm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Resulting RPM can be found here:
https://github.com/der-eismann/kvrocks-fpm/releases/tag/2.9.0-1

Contents:
```
$ rpm -ql kvrocks-2.9.0-1.x86_64.rpm                                                                      
/etc/kvrocks/kvrocks.conf
/usr/bin/kvrocks
/usr/bin/kvrocks2redis
/usr/lib/.build-id
/usr/lib/.build-id/44
/usr/lib/.build-id/44/c10ad9b980f84b93b2b72bf12e85debb35ee44
/usr/lib/.build-id/d6
/usr/lib/.build-id/d6/4c002f83c7803074be42251bff5cb6d370c6ed
/usr/lib/systemd/system/kvrocks.service
/usr/share/licenses/kvrocks/LICENSE
/usr/share/licenses/kvrocks/LICENSE-LuaJIT.txt
/usr/share/licenses/kvrocks/LICENSE-cpptrace.txt
/usr/share/licenses/kvrocks/LICENSE-fmt.txt
/usr/share/licenses/kvrocks/LICENSE-glog.txt
/usr/share/licenses/kvrocks/LICENSE-googletest.txt
/usr/share/licenses/kvrocks/LICENSE-hat-trie.txt
/usr/share/licenses/kvrocks/LICENSE-jsoncons.txt
/usr/share/licenses/kvrocks/LICENSE-libevent.txt
/usr/share/licenses/kvrocks/LICENSE-lua.txt
/usr/share/licenses/kvrocks/LICENSE-lz4.txt
/usr/share/licenses/kvrocks/LICENSE-pegtl.txt
/usr/share/licenses/kvrocks/LICENSE-range-v3.txt
/usr/share/licenses/kvrocks/LICENSE-redis.txt
/usr/share/licenses/kvrocks/LICENSE-snappy.txt
/usr/share/licenses/kvrocks/LICENSE-span-lite.txt
/usr/share/licenses/kvrocks/LICENSE-xxhash.txt
/usr/share/licenses/kvrocks/LICENSE-zlib.txt
/usr/share/licenses/kvrocks/NOTICE
```